### PR TITLE
Bugfix show greeting image on mobile version gmail

### DIFF
--- a/src/email/components/Greeting/Greeting.css
+++ b/src/email/components/Greeting/Greeting.css
@@ -22,15 +22,15 @@
 
 .greeting-title {
 	font-weight: bold;
-	font-size: 26px;
+	font-size: 22px;
 	line-height: 30px;
 	color: #0f204d;
 	margin-bottom: 10px;
 }
 
-@media only screen and (max-width: 600px) {
+@media screen and (min-width: 600px) {
 	.greeting-title {
-		font-size: 22px;
+		font-size: 26px;
 	}
 }
 
@@ -39,11 +39,11 @@
 }
 
 .greeting-img {
-	display: block;
+	display: none;
 }
 
-@media only screen and (max-width: 600px) {
+@media only screen and (min-width: 600px) {
 	.greeting-img {
-		display: none;
+		display: block;
 	}
 }

--- a/src/email/components/Header/Header.css
+++ b/src/email/components/Header/Header.css
@@ -19,13 +19,13 @@
 	white-space: nowrap;
 	color: #0f204d;
 	text-transform: uppercase;
-	font-size: 12px;
+	font-size: 10px;
 	font-weight: 700;
 }
 
-@media only screen and (max-width: 600px) {
+@media only screen and (min-width: 600px) {
 	.issue {
-		font-size: 10px;
+		font-size: 12px;
 	}
 }
 


### PR DESCRIPTION
hides the greeting-img in the Greeting component in the mobile version of the email (using mobile first approach)