### PR TITLE
change the horizontal alignment of the logo

### DIFF
--- a/src/landing/components/AppBar/AppBar.css
+++ b/src/landing/components/AppBar/AppBar.css
@@ -23,7 +23,7 @@
 	.app-bar-content-wrap {
 		justify-content: center;
 
-		width: 414px;
-		margin-left: auto;
+		max-width: 414px;
+		margin: 0 auto;
 	}
 }


### PR DESCRIPTION
now it is always in the center relative to other elements of the sidebar